### PR TITLE
Build for ARM. Clean up GitHub action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build-push-action.yml
+++ b/.github/workflows/build-push-action.yml
@@ -2,27 +2,48 @@ name: build-push
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        if: github.repository == 'robertdebock/docker-debian-systemd'
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Set short
-        run: echo "short=${GITHUB_REF##*/}" >> "${GITHUB_ENV}"
-      - name: Set tag
-        run: echo "tag=${short/master/latest}" >> "${GITHUB_ENV}"
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
         with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            robertdebock/debian,enable=${{ github.repository == 'robertdebock/docker-debian-systemd' }}
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: robertdebock/debian:${{ env.tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Here is a quick PR to enable build for ARM64

* Updated to latest action versions
* Enabled for both `linux/amd64` and `linux/arm64`
* Make Docker Hub login conditional (fork safe)
* Also push Docker image to GitHub Container Registry
* Replace custom tag logic with `docker/metadata-action` (fork safe)
* Enable GHA container build caching
* Enable dependabot to PR action updates

Successful build here: https://github.com/Firefishy/docker-debian-systemd/actions/runs/7131652574